### PR TITLE
Allows users to use goinstall

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,6 @@ TARG=pcap
 GOFILES=decode.go\
 	io.go
 CGOFILES=pcap.go
-CGO_LDFLAGS=-lpcap
 CLEANFILES=pcaptest tcpdump
 
 include $(GOROOT)/src/Make.pkg

--- a/pcap.go
+++ b/pcap.go
@@ -1,6 +1,7 @@
 package pcap
 
 /*
+#cgo LDFLAGS: -lpcap
 struct pcap { int dummy; };
 #include <stdlib.h>
 #include <pcap.h>


### PR DESCRIPTION
Goinstall makes things a lot easier on the developer. This should continue to work the old way (using the Makefile) as well as allow users to execute `goinstall github.com/strogman/gopcap`
